### PR TITLE
Add an explicit timeout; makes debugging easier, point out the obviou…

### DIFF
--- a/test/PoE-test/tussendeur-asis-2017/tussendeur-asis-2017.ino
+++ b/test/PoE-test/tussendeur-asis-2017/tussendeur-asis-2017.ino
@@ -419,7 +419,7 @@ void closeDoor() {
 
 void openDoor() {
   char msg[255];
-  snprintf(msg, sizeof(msg), "[%p] Engaging solenoid", pname);
+  snprintf(msg, sizeof(msg), "[%s] Engaging solenoid", pname);
   doorstate = OPEN;
   client.publish(log_topic, msg);
   Serial.println(msg);


### PR DESCRIPTION
…s backend-issue wiht naive-caching and cleanup the output as to allow it to be mixed with that of other nodes in one channel.